### PR TITLE
AppCell에서 오토레이아웃 충돌나는 문제 해결

### DIFF
--- a/AppStoreSearchApp/Base.lproj/Main.storyboard
+++ b/AppStoreSearchApp/Base.lproj/Main.storyboard
@@ -155,7 +155,7 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="G5P-Lh-QBY" secondAttribute="bottom" constant="15" id="BZd-PC-DOL"/>
+                                                <constraint firstAttribute="bottom" secondItem="G5P-Lh-QBY" secondAttribute="bottom" priority="999" constant="15" id="BZd-PC-DOL"/>
                                                 <constraint firstItem="G5P-Lh-QBY" firstAttribute="leading" secondItem="JbR-aW-r20" secondAttribute="leading" constant="15" id="KlX-fM-8c2"/>
                                                 <constraint firstItem="G5P-Lh-QBY" firstAttribute="top" secondItem="JbR-aW-r20" secondAttribute="top" constant="15" id="WdY-2g-ePw"/>
                                                 <constraint firstAttribute="trailing" secondItem="G5P-Lh-QBY" secondAttribute="trailing" constant="15" id="shD-79-gVh"/>

--- a/AppStoreSearchApp/View/AppCell.swift
+++ b/AppStoreSearchApp/View/AppCell.swift
@@ -59,6 +59,7 @@ class AppCell: UITableViewCell {
             screenShotsStackView.addArrangedSubview(imageView)
             imageView.translatesAutoresizingMaskIntoConstraints = false
             imageView.widthAnchor.constraint(equalTo: screenShotsStackView.widthAnchor, multiplier: 1).isActive = true
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 228.0/406.0).isActive = true
         }
     }
     


### PR DESCRIPTION
- 스크린샷 이미지가 동적으로 추가되면서 셀 높이가 고정되어 있어서 충돌이 일어나는 문제가 발생
- 셀 높이를 고정시키는 오토레이아웃의 우선순위를 낮춤으로써 해결